### PR TITLE
Added support for managing user permission level via config file

### DIFF
--- a/Functions/Export-GomUser.ps1
+++ b/Functions/Export-GomUser.ps1
@@ -30,6 +30,14 @@ function Export-GomUser {
             $UserConfig | Add-Member -MemberType NoteProperty -Name UserType -Value $_.type
         }
 
+        $GetUserRole = @{
+            UriFragment = "orgs/$OrganizationName/memberships/$UserName"
+            Method = "Get"
+        }
+        
+        $UserRole = $(Invoke-GHRestMethod @GetUserRole).Role
+        $UserConfig | Add-Member -MemberType NoteProperty -Name Role -Value $UserRole
+
         $OutFile = "${RepoRoot}/Users/${UserName}.json"
 
         if(Test-Path $OutFile){

--- a/Functions/Export-GomUser.ps1
+++ b/Functions/Export-GomUser.ps1
@@ -35,7 +35,7 @@ function Export-GomUser {
             Method = "Get"
         }
         
-        $UserRole = $(Invoke-GHRestMethod @GetUserRole).Role
+        $UserRole = (Invoke-GHRestMethod @GetUserRole).Role
         $UserConfig | Add-Member -MemberType NoteProperty -Name Role -Value $UserRole
 
         $OutFile = "${RepoRoot}/Users/${UserName}.json"

--- a/Functions/Sync-GomUser.ps1
+++ b/Functions/Sync-GomUser.ps1
@@ -29,12 +29,8 @@ function Sync-GomUser {
 
     foreach($User in $ConfigUsers) {
         $UserName = $User.Name
-        if($UserName -NotIn $ExistingUsers.login){
-            Write-Host "Adding user '$UserName' to Organization '$OrganizationName'."
-            Deploy-GomUser -OrganizationName $OrganizationName -UserName $UserName
-        } else{
-            Write-Verbose "User '$UserName' already exists in Organization '$OrganizationName'."
-        }
+        $UserRole = $User.Role
+        Deploy-GomUser -OrganizationName $OrganizationName -UserName $UserName -UserRole $UserRole
     }
 
     $ExistingUsers | Where-Object {


### PR DESCRIPTION
You can now configure a user's role in the organization via the `Role` attribute in their user config file, as seen below. Role is also exported from github into the config file as expected. This supports setting the role for both new and existing users in the organization.
```json
# admin level
{
  "Name": "wayne-duke-sh",
  "Id": 110645584,
  "Role": "admin"
}
```
```json
# standard member level
{
  "Name": "RajeshPatel17",
  "Id": 67518979,
  "Role": "member"
}
```